### PR TITLE
Add SpawnFeature and register in Entrypoint

### DIFF
--- a/src/main/kotlin/live/einfachgustaf/smp/Entrypoint.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/Entrypoint.kt
@@ -2,6 +2,7 @@ package live.einfachgustaf.smp
 
 import live.einfachgustaf.smp.core.feature.FeatureContext
 import live.einfachgustaf.smp.core.feature.FeatureManager
+import live.einfachgustaf.smp.features.SpawnFeature
 import live.einfachgustaf.smp.utils.registerSimple
 import live.einfachgustaf.smp.utils.servicesManager
 import org.bukkit.plugin.java.JavaPlugin
@@ -15,7 +16,7 @@ class Entrypoint: JavaPlugin() {
 
         featureManager = FeatureManager(FeatureContext(this)).apply {
             // register all features
-            // ...
+            register(SpawnFeature())
         }
         servicesManager.registerSimple(featureManager)
     }

--- a/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
@@ -30,6 +30,5 @@ class SpawnFeature(override val name: String = "Spawn") : Feature {
         }
     }
 
-    override fun disable() {
-    }
+    override fun disable() = Unit
 }

--- a/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
@@ -21,7 +21,7 @@ class SpawnFeature(override val name: String = "Spawn") : Feature {
                     .requires { it.sender is Player }
                     .executes { ctx ->
                         val player = ctx.source.sender as Player
-                        val loc = getSpawnLocation()
+                        val loc = Bukkit.getWorlds().first().spawnLocation
                         player.teleportAsync(loc)
                         player.sendMessage(Component.text("Du wurdest zum Spawn teleportiert!")) // TODO: better message + sound
                         return@executes 1
@@ -31,10 +31,5 @@ class SpawnFeature(override val name: String = "Spawn") : Feature {
     }
 
     override fun disable() {
-    }
-
-    private fun getSpawnLocation(): Location {
-        val world = Bukkit.getWorlds().firstOrNull() ?: throw IllegalStateException("No world loaded!")
-        return world.spawnLocation
     }
 }

--- a/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
@@ -6,7 +6,6 @@ import live.einfachgustaf.smp.core.feature.Feature
 import live.einfachgustaf.smp.core.feature.FeatureContext
 import net.kyori.adventure.text.Component
 import org.bukkit.Bukkit
-import org.bukkit.Location
 import org.bukkit.entity.Player
 
 class SpawnFeature(override val name: String = "Spawn") : Feature {

--- a/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
@@ -36,7 +36,7 @@ class SpawnFeature(override val name: String = "Spawn") : Feature {
     }
 
     private fun getSpawnLocation(): Location {
-        val world = Bukkit.getWorlds().firstOrNull() ?: throw IllegalStateException("Keine Welt geladen")
+        val world = Bukkit.getWorlds().firstOrNull() ?: throw IllegalStateException("No world loaded!")
         return world.spawnLocation
     }
 }

--- a/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
@@ -1,0 +1,43 @@
+package live.einfachgustaf.smp.features
+
+import io.papermc.paper.command.brigadier.Commands
+import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents
+import live.einfachgustaf.smp.core.feature.Feature
+import live.einfachgustaf.smp.core.feature.FeatureContext
+import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
+import org.bukkit.Location
+
+class SpawnFeature(override val name: String = "Spawn") : Feature {
+
+    @Suppress("UnstableApiUsage")
+    override fun enable(context: FeatureContext) {
+        context.plugin.lifecycleManager.registerEventHandler(LifecycleEvents.COMMANDS) {
+            val commands = it.registrar()
+
+            commands.register(
+                Commands.literal("spawn")
+                    .executes { ctx ->
+                        val sender = ctx.source.sender
+                        if (sender is org.bukkit.entity.Player) {
+                            val loc = getSpawnLocation()
+                            sender.teleportAsync(loc)
+                            sender.sendMessage(Component.text("Du wurdest zum Spawn teleportiert!")) // TODO: better message + sound
+                            return@executes 1
+                        }
+                        sender.sendMessage(Component.text("Nur Spieler können diesen Befehl nutzen.")) // TODO: better message + sound
+                        0
+                    }.build()
+            )
+        }
+    }
+
+    override fun disable() {
+        TODO("Not yet implemented")
+    }
+
+    private fun getSpawnLocation(): Location {
+        val world = Bukkit.getWorlds().firstOrNull() ?: throw IllegalStateException("Keine Welt geladen")
+        return world.spawnLocation
+    }
+}

--- a/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
@@ -33,7 +33,6 @@ class SpawnFeature(override val name: String = "Spawn") : Feature {
     }
 
     override fun disable() {
-        TODO("Not yet implemented")
     }
 
     private fun getSpawnLocation(): Location {

--- a/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
+++ b/src/main/kotlin/live/einfachgustaf/smp/features/SpawnFeature.kt
@@ -7,26 +7,24 @@ import live.einfachgustaf.smp.core.feature.FeatureContext
 import net.kyori.adventure.text.Component
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.entity.Player
 
 class SpawnFeature(override val name: String = "Spawn") : Feature {
 
     @Suppress("UnstableApiUsage")
     override fun enable(context: FeatureContext) {
-        context.plugin.lifecycleManager.registerEventHandler(LifecycleEvents.COMMANDS) {
-            val commands = it.registrar()
+        context.plugin.lifecycleManager.registerEventHandler(LifecycleEvents.COMMANDS) { event ->
+            val commands = event.registrar()
 
             commands.register(
                 Commands.literal("spawn")
+                    .requires { it.sender is Player }
                     .executes { ctx ->
-                        val sender = ctx.source.sender
-                        if (sender is org.bukkit.entity.Player) {
-                            val loc = getSpawnLocation()
-                            sender.teleportAsync(loc)
-                            sender.sendMessage(Component.text("Du wurdest zum Spawn teleportiert!")) // TODO: better message + sound
-                            return@executes 1
-                        }
-                        sender.sendMessage(Component.text("Nur Spieler können diesen Befehl nutzen.")) // TODO: better message + sound
-                        0
+                        val player = ctx.source.sender as Player
+                        val loc = getSpawnLocation()
+                        player.teleportAsync(loc)
+                        player.sendMessage(Component.text("Du wurdest zum Spawn teleportiert!")) // TODO: better message + sound
+                        return@executes 1
                     }.build()
             )
         }

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -3,3 +3,4 @@ version: '1.0'
 main: live.einfachgustaf.smp.Entrypoint
 api-version: '1.21.6'
 folia-supported: true
+load: POSTWORLD


### PR DESCRIPTION
Introduces the SpawnFeature class, which provides a /spawn command to teleport players to the world's spawn location. The feature is registered in Entrypoint to enable its functionality.